### PR TITLE
Switch to modern resume theme

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 # Site
-repository: sproogen/resume-theme
+repository: sproogen/modern-resume-theme
 favicon: images/favicon.ico
 
 # Content configuration version
@@ -119,7 +119,7 @@ footer_show_references: true
 # references_title: References on request (Override references text)
 
 # Build settings
-remote_theme: sproogen/resume-theme
+remote_theme: sproogen/modern-resume-theme
 
 sass:
   sass_dir: _sass


### PR DESCRIPTION
## Summary
- update Jekyll configuration to use `sproogen/modern-resume-theme`

## Testing
- `bundle install`
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_6861dd508618832a9076658a16f523a1