### PR TITLE
Fix education subtitle

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -98,7 +98,7 @@ content:
       - layout: left
         title: RMIT
         caption: 2008 - 2015
-        sub_title: B.It
+        sub_title: B.IT
         quote: >
           RMIT has a global reputation for excellence in professional and vocational education, applied research, and engagement with the needs of industry and communities world-wide. 22nd globally in the 2022 Times Higher Education Impact Rankings.
         description: | # this will include new lines to allow paragraphs


### PR DESCRIPTION
## Summary
- capitalize the RMIT degree under the education section

## Testing
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_68623f34ab68832a90bd588a499eaa18